### PR TITLE
Previously registered protocols were unregistered.

### DIFF
--- a/JiveLoggingHTTPProtocol.podspec
+++ b/JiveLoggingHTTPProtocol.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'JiveLoggingHTTPProtocol'
-  s.version = '0.2.2'
+  s.version = '0.2.3'
   s.license = { :type => 'BSD', :file => 'LICENSE' }
   s.summary = 'An NSURLProtocol to log HTTP Requests and Responses'
   s.homepage = 'https://github.com/jivesoftware/JiveLoggingHTTPProtocol'

--- a/Source/JiveLoggingHTTPProtocol/JLHPLoggingHTTPProtocol.m
+++ b/Source/JiveLoggingHTTPProtocol/JLHPLoggingHTTPProtocol.m
@@ -105,7 +105,11 @@
         config = [NSURLSessionConfiguration defaultSessionConfiguration];
         // You have to explicitly configure the session to use your own protocol subclass here 
         // otherwise you don't see redirects <rdar://problem/17384498>.
-        config.protocolClasses = @[ self ];
+        if (config.protocolClasses) {
+            config.protocolClasses = [config.protocolClasses arrayByAddingObject:self];
+        } else {
+            config.protocolClasses = @[ self ];
+        }
         sDemux = [[JLHPQNSURLSessionDemux alloc] initWithConfiguration:config];
     });
     return sDemux;


### PR DESCRIPTION
If another NSURLProtocol was registered on the NSURLSession's
defaultConfiguration, it would be unregistered when
JLHPLoggingHTTPProtocol was registered and used.
